### PR TITLE
compile fixes for !HAVE_GSS_USEROK and !HAVE_GSS_INDICATE_MECHS_BY_ATTRS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3650,6 +3650,7 @@ AC_ARG_WITH(kerberos5,
 		AC_SEARCH_LIBS(k_hasafs, kafs, AC_DEFINE(USE_AFS, 1,
 			[Define this if you want to use libkafs' AFS support]))
 		AC_CHECK_FUNCS( gss_localname gss_userok)
+		AC_CHECK_FUNCS([gss_indicate_mechs_by_attrs])
 	fi
 	]
 )

--- a/gss-serv.c
+++ b/gss-serv.c
@@ -73,6 +73,7 @@ static int ssh_gssapi_generic_userok(
 }
 #endif
 
+#ifdef HAVE_GSS_USEROK
 static int
 ssh_gssapi_generic_localname(ssh_gssapi_client *client,
 			  char **localname) {
@@ -100,7 +101,6 @@ ssh_gssapi_generic_localname(ssh_gssapi_client *client,
   #endif
       }
 
-#ifdef HAVE_GSS_USEROK
 static ssh_gssapi_mech ssh_gssapi_generic_mech = {
   NULL, NULL,
   {0, NULL},
@@ -111,7 +111,7 @@ static ssh_gssapi_mech ssh_gssapi_generic_mech = {
   NULL};
 static const ssh_gssapi_mech *ssh_gssapi_generic_mech_ptr = &ssh_gssapi_generic_mech;
 #else /*HAVE_GSS_USEROK*/
-static const ssh_gssapi_mech ssh_gssapi_generic_mech_ptr = NULL;
+static const ssh_gssapi_mech *ssh_gssapi_generic_mech_ptr = NULL;
 #endif
 
 #ifdef KRB5
@@ -211,6 +211,8 @@ ssh_gssapi_supported_oids(gss_OID_set *oidset)
 	OM_uint32 min_status;
 	int present;
 	gss_OID_set supported;
+
+#ifdef HAVE_GSS_INDICATE_MECHS_BY_ATTRS
 	/* If we have a generic mechanism all OIDs supported */
 	if (ssh_gssapi_generic_mech_ptr) {
 	  gss_OID_desc except_oids[3];
@@ -229,6 +231,7 @@ ssh_gssapi_supported_oids(gss_OID_set *oidset)
 						     oidset)))
 	    return;
 	}
+#endif
 
 	gss_create_empty_oid_set(&min_status, oidset);
 


### PR DESCRIPTION
Fixes for compiling against GSI GSSAPI which doesn't (yet) have gss_userok() or gss_indicate_mechs_by_attrs(). Needed so I can include support for generic GSS-API mechanisms in the GSI-OpenSSH code base (https://github.com/ncsa/gsi-openssh).

Compiler warnings/errors fixed are:

```
gss-serv.c:81:1: warning: unused function 'ssh_gssapi_generic_localname'
gss-serv.c:118:30: error: initializing 'const ssh_gssapi_mech' with an expression of incompatible type 'void *'
gss-serv.c:251:22: error: use of undeclared identifier 'GSS_C_MA_MECH_NEGO'
gss-serv.c:252:22: error: use of undeclared identifier 'GSS_C_MA_NOT_MECH'
gss-serv.c:253:22: error: use of undeclared identifier 'GSS_C_MA_DEPRECATED'
gss-serv.c:258:19: warning: implicit declaration of function 'gss_indicate_mechs_by_attrs'
```
